### PR TITLE
Fix GCC's __FPU_Enable for Cortex-A for no optimisation

### DIFF
--- a/CMSIS/CoreValidation/Layer/App/Validation_Cortex-A/App.clayer.yml
+++ b/CMSIS/CoreValidation/Layer/App/Validation_Cortex-A/App.clayer.yml
@@ -23,7 +23,6 @@ layer:
     - for-compiler: GCC
       C-CPP:
       - -Wno-declaration-after-statement
-      - -Wno-covered-switch-default
 
   groups:
     - group: Documentation

--- a/CMSIS/CoreValidation/Layer/App/Validation_Cortex-M/App.clayer.yml
+++ b/CMSIS/CoreValidation/Layer/App/Validation_Cortex-M/App.clayer.yml
@@ -23,7 +23,6 @@ layer:
     - for-compiler: GCC
       C-CPP:
       - -Wno-declaration-after-statement
-      - -Wno-covered-switch-default
 
   groups:
     - group: Documentation


### PR DESCRIPTION
At -O0 the pseudo instruction LDR R2,=0x00086060
caused the literal pool to be created out of range.