### PR TITLE
Pack generation: Use same version of gen-pack library

### DIFF
--- a/CMSIS/Documentation/Doxygen/gen_doc.sh
+++ b/CMSIS/Documentation/Doxygen/gen_doc.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.8.4"
+REQUIRED_GEN_PACK_LIB="0.8.7"
 
 DIRNAME=$(dirname $(readlink -f $0))
 GENDIR=../html

--- a/gen_pack.sh
+++ b/gen_pack.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.8.5"
+REQUIRED_GEN_PACK_LIB="0.8.7"
 
 # Set default command line arguments
 DEFAULT_ARGS=(-c "v")


### PR DESCRIPTION
Use same version of gen-pack library for gen_pack.sh and gen_doc.sh as used by check_links.sh