### PR TITLE
Core: Update __NO_INIT docu and implementation for AC6

### DIFF
--- a/CMSIS/Core/Include/m-profile/cmsis_armclang_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_armclang_m.h
@@ -100,7 +100,7 @@
   #define __COMPILER_BARRIER()                   __ASM volatile("":::"memory")
 #endif
 #ifndef __NO_INIT
-  #define __NO_INIT                              __attribute__ ((section (".noinit")))
+  #define __NO_INIT                              __attribute__ ((section (".bss.noinit")))
 #endif
 #ifndef __ALIAS
   #define __ALIAS(x)                             __attribute__ ((alias(x)))

--- a/CMSIS/Documentation/Doxygen/Core/src/ref_compiler_ctrl.txt
+++ b/CMSIS/Documentation/Doxygen/Core/src/ref_compiler_ctrl.txt
@@ -404,13 +404,15 @@ void test (uint8_t *ptr) {
 /**************************************************************************************************/
 /**
 \def __NO_INIT
-\brief Force symbol into uninitialized memory section
+\brief Specifies a section name for a variable to simplify variable placement into a non-initialized memory
 \details
-This puts a symbol (such as a variable) into an uninitialized memory section (e.g, .bss.noinit).
+Specifies a section name (e.g, .bss.noinit or .noinit) for a variable that can be used by a linker-script
+to position that variable into a non-initialized memory.
 
 <b>Code Example:</b>
-The EventBuffer in the example does not need to be copy- or zero-initialized. By adding
-__NO_INIT this variable is allocated into an uninitialized memory section.
+The EventBuffer in the example must not be copy- or zero-initialized. By adding
+__NO_INIT at variable declaration/definition, and with appropriate linker-script, this variable is
+positioned into a non-initialized memory.
 
 \code
 static EventRecord_t EventBuffer[EVENT_RECORD_COUNT] __NO_INIT __ALIGNED(16);


### PR DESCRIPTION
Added `.bss` at beginning of the section name as required by Arm Compiler 6.

Clarified description of the macro in the documentation.