### PR TITLE
Use __ARM_FP to detect FPU

### DIFF
--- a/CMSIS/Core/Include/m-profile/cmsis_iccarm_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_iccarm_m.h
@@ -327,8 +327,7 @@ __STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
   #define __get_CONTROL()             (__arm_rsr("CONTROL"))
   #define __get_FAULTMASK()           (__arm_rsr("FAULTMASK"))
 
-  #if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
-       (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+  #if (defined (__ARM_FP)      && (__ARM_FP >= 1)) 
     #define __get_FPSCR()             (__arm_rsr("FPSCR"))
     #define __set_FPSCR(VALUE)        (__arm_wsr("FPSCR", (VALUE)))
   #else
@@ -602,8 +601,7 @@ __STATIC_FORCEINLINE void __TZ_set_CONTROL_NS(uint32_t control)
 
   #endif
 
-  #if (!((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
-         (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     ))
+  #if !((defined (__ARM_FP)      && (__ARM_FP >= 1)) 
     #undef __get_FPSCR
     #undef __set_FPSCR
     #define __get_FPSCR()       (0)


### PR DESCRIPTION
There are some issues with header include order and this makes FPSCR intrinsic fail on IAR.

We change it to use compiler ACLE defines instead.