### PR TITLE
CMSIS-Driver: remove return tag from documentation for void functions

### DIFF
--- a/CMSIS/Driver/Include/Driver_CAN.h
+++ b/CMSIS/Driver/Include/Driver_CAN.h
@@ -318,13 +318,11 @@ typedef struct _ARM_CAN_STATUS {
   \fn          void ARM_CAN_SignalUnitEvent (uint32_t event)
   \brief       Signal CAN unit event.
   \param[in]   event \ref CAN_unit_events
-  \return      none
 
   \fn          void ARM_CAN_SignalObjectEvent (uint32_t obj_idx, uint32_t event)
   \brief       Signal CAN object event.
   \param[in]   obj_idx  Object index
   \param[in]   event \ref CAN_events
-  \return      none
 */
 
 typedef void (*ARM_CAN_SignalUnitEvent_t)   (uint32_t event);                   ///< Pointer to \ref ARM_CAN_SignalUnitEvent   : Signal CAN Unit Event.

--- a/CMSIS/Driver/Include/Driver_ETH_MAC.h
+++ b/CMSIS/Driver/Include/Driver_ETH_MAC.h
@@ -250,7 +250,6 @@ typedef struct _ARM_ETH_MAC_TIME {
   \fn          void ARM_ETH_MAC_SignalEvent (uint32_t event)
   \brief       Callback function that signals a Ethernet Event.
   \param[in]   event  event notification mask
-  \return      none
 */
 
 typedef void (*ARM_ETH_MAC_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event.

--- a/CMSIS/Driver/Include/Driver_Flash.h
+++ b/CMSIS/Driver/Include/Driver_Flash.h
@@ -168,7 +168,6 @@ typedef struct _ARM_FLASH_STATUS {
   \fn          void ARM_Flash_SignalEvent (uint32_t event)
   \brief       Signal Flash event.
   \param[in]   event  Event notification mask
-  \return      none
 */
 
 typedef void (*ARM_Flash_SignalEvent_t) (uint32_t event);    ///< Pointer to \ref ARM_Flash_SignalEvent : Signal Flash Event.

--- a/CMSIS/Driver/Include/Driver_MCI.h
+++ b/CMSIS/Driver/Include/Driver_MCI.h
@@ -291,7 +291,6 @@ typedef struct _ARM_MCI_STATUS {
   \fn            void ARM_MCI_SignalEvent (uint32_t event)
   \brief         Callback function that signals a MCI Card Event.
   \param[in]     event \ref mci_event_gr
-  \return        none
 */
 
 typedef void (*ARM_MCI_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_MCI_SignalEvent : Signal MCI Card Event.

--- a/CMSIS/Driver/Include/Driver_NAND.h
+++ b/CMSIS/Driver/Include/Driver_NAND.h
@@ -357,7 +357,6 @@ typedef struct _ARM_NAND_STATUS {
   \brief         Signal NAND event.
   \param[in]     dev_num  Device number
   \param[in]     event    Event notification mask
-  \return        none
 */
 
 typedef void (*ARM_NAND_SignalEvent_t) (uint32_t dev_num, uint32_t event);    ///< Pointer to \ref ARM_NAND_SignalEvent : Signal NAND Event.

--- a/CMSIS/Driver/Include/Driver_SAI.h
+++ b/CMSIS/Driver/Include/Driver_SAI.h
@@ -266,7 +266,6 @@ typedef struct _ARM_SAI_STATUS {
   \fn          void ARM_SAI_SignalEvent (uint32_t event)
   \brief       Signal SAI Events.
   \param[in]   event \ref SAI_events notification mask
-  \return      none
 */
 
 typedef void (*ARM_SAI_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_SAI_SignalEvent : Signal SAI Event.

--- a/CMSIS/Driver/Include/Driver_SPI.h
+++ b/CMSIS/Driver/Include/Driver_SPI.h
@@ -210,7 +210,6 @@ typedef struct _ARM_SPI_STATUS {
   \fn          void ARM_SPI_SignalEvent (uint32_t event)
   \brief       Signal SPI Events.
   \param[in]   event \ref SPI_events notification mask
-  \return      none
 */
 
 typedef void (*ARM_SPI_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_SPI_SignalEvent : Signal SPI Event.

--- a/CMSIS/Driver/Include/Driver_USART.h
+++ b/CMSIS/Driver/Include/Driver_USART.h
@@ -283,7 +283,6 @@ typedef struct _ARM_USART_MODEM_STATUS {
   \fn          void ARM_USART_SignalEvent (uint32_t event)
   \brief       Signal USART Events.
   \param[in]   event  \ref USART_events notification mask
-  \return      none
 */
 
 typedef void (*ARM_USART_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_USART_SignalEvent : Signal USART Event.

--- a/CMSIS/Driver/Include/Driver_USBD.h
+++ b/CMSIS/Driver/Include/Driver_USBD.h
@@ -216,7 +216,6 @@ typedef struct _ARM_USBD_STATE {
   \fn          void ARM_USBD_SignalDeviceEvent (uint32_t event)
   \brief       Signal USB Device Event.
   \param[in]   event \ref USBD_dev_events
-  \return      none
 */
 /**
   \fn          void ARM_USBD_SignalEndpointEvent (uint8_t ep_addr, uint32_t event)
@@ -225,7 +224,6 @@ typedef struct _ARM_USBD_STATE {
                 - ep_addr.0..3: Address
                 - ep_addr.7:    Direction
   \param[in]   event \ref USBD_ep_events
-  \return      none
 */
 
 typedef void (*ARM_USBD_SignalDeviceEvent_t)   (uint32_t event);                    ///< Pointer to \ref ARM_USBD_SignalDeviceEvent : Signal USB Device Event.

--- a/CMSIS/Driver/Include/Driver_USBH.h
+++ b/CMSIS/Driver/Include/Driver_USBH.h
@@ -275,14 +275,12 @@ typedef uint32_t ARM_USBH_PIPE_HANDLE;
   \brief       Signal Root HUB Port Event.
   \param[in]   port  Root HUB Port Number
   \param[in]   event \ref USBH_port_events
-  \return      none
 */
 /**
   \fn          void ARM_USBH_SignalPipeEvent (ARM_USBH_PIPE_HANDLE pipe_hndl, uint32_t event)
   \brief       Signal Pipe Event.
   \param[in]   pipe_hndl  Pipe Handle
   \param[in]   event  \ref USBH_pipe_events
-  \return      none
 */
 
 typedef void (*ARM_USBH_SignalPortEvent_t) (uint8_t port, uint32_t event);                    ///< Pointer to \ref ARM_USBH_SignalPortEvent : Signal Root HUB Port Event.
@@ -387,7 +385,6 @@ typedef struct _ARM_DRIVER_USBH {
 /**
   \fn          void ARM_USBH_HCI_Interrupt (void)
   \brief       USB Host HCI Interrupt Handler.
-  \return      none
 */
 
 typedef void (*ARM_USBH_HCI_Interrupt_t) (void);  ///< Pointer to Interrupt Handler Routine.

--- a/CMSIS/Driver/Include/Driver_WiFi.h
+++ b/CMSIS/Driver/Include/Driver_WiFi.h
@@ -595,7 +595,6 @@ typedef struct ARM_WIFI_NET_INFO_s {
   \brief         Signal WiFi Events.
   \param[in]     event    \ref wifi_event notification mask
   \param[in]     arg      Pointer to argument of signaled event
-  \return        none
 */
 
 typedef void (*ARM_WIFI_SignalEvent_t) (uint32_t event, void *arg); ///< Pointer to \ref ARM_WIFI_SignalEvent : Signal WiFi Event.


### PR DESCRIPTION
- avoid doxygen warnings