### PR TITLE
Core: corrected use of #ifdef __ICACHE_PRESENT / __DCACHE_PRESENT (#134)

### DIFF
--- a/CMSIS/CoreValidation/Source/CV_CML1Cache.c
+++ b/CMSIS/CoreValidation/Source/CV_CML1Cache.c
@@ -2,7 +2,7 @@
  *      Name:         CV_CML1Cache.c 
  *      Purpose:      CMSIS CORE validation tests implementation
  *-----------------------------------------------------------------------------
- *      Copyright (c) 2020 - 2021 ARM Limited. All rights reserved.
+ *      Copyright (c) 2020 - 2024 ARM Limited. All rights reserved.
  *----------------------------------------------------------------------------*/
 
 #include "CV_Framework.h"
@@ -18,7 +18,7 @@
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 void TC_CML1Cache_EnDisableICache(void) {
-#ifdef __ICACHE_PRESENT
+#if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
   SCB_EnableICache();
   
   ASSERT_TRUE((SCB->CCR & SCB_CCR_IC_Msk) == SCB_CCR_IC_Msk);
@@ -31,7 +31,7 @@ void TC_CML1Cache_EnDisableICache(void) {
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
 void TC_CML1Cache_EnDisableDCache(void) {
-#ifdef __DCACHE_PRESENT
+#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   SCB_EnableDCache();
 
   ASSERT_TRUE((SCB->CCR & SCB_CCR_DC_Msk) == SCB_CCR_DC_Msk);
@@ -43,12 +43,12 @@ void TC_CML1Cache_EnDisableDCache(void) {
 }
 
 /*=======0=========1=========2=========3=========4=========5=========6=========7=========8=========9=========0=========1====*/
-#ifdef __DCACHE_PRESENT
+#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
 static uint32_t TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values[] = { 42U, 0U, 8U, 15U };
 #endif
 
 void TC_CML1Cache_CleanDCacheByAddrWhileDisabled(void) {
-#ifdef __DCACHE_PRESENT
+#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   SCB_DisableDCache();
   SCB_CleanDCache_by_Addr(TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values, sizeof(TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values)/sizeof(TC_CML1Cache_CleanDCacheByAddrWhileDisabled_Values[0]));
   ASSERT_TRUE((SCB->CCR & SCB_CCR_DC_Msk) == 0U);

--- a/CMSIS/CoreValidation/Source/Config/CV_Config.h
+++ b/CMSIS/CoreValidation/Source/Config/CV_Config.h
@@ -2,7 +2,7 @@
  *      Name:         CV_Config.h
  *      Purpose:      CV Config header
  *----------------------------------------------------------------------------
- *      Copyright (c) 2017 - 2018 Arm Limited. All rights reserved.
+ *      Copyright (c) 2017 - 2024 Arm Limited. All rights reserved.
  *----------------------------------------------------------------------------*/
 #ifndef __CV_CONFIG_H
 #define __CV_CONFIG_H
@@ -14,7 +14,8 @@
 #define RTE_CV_COREFUNC  1
 #define RTE_CV_CORESIMD  1
 #define RTE_CV_MPUFUNC   (__MPU_PRESENT)
-#if defined __ICACHE_PRESENT || defined __DCACHE_PRESENT
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
 #define RTE_CV_L1CACHE   (__ICACHE_PRESENT || __DCACHE_PRESENT)
 #endif
 


### PR DESCRIPTION
Updated use of  #ifdef __ICACHE_PRESENT, #ifdef __DCACHE_PRESENT 