### PR TITLE
Fix miner issues:

### DIFF
--- a/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/startup_ARMCA5.s
+++ b/CMSIS/CoreValidation/Layer/Target/CA5/RTE/Device/ARMCA5/startup_ARMCA5.s
@@ -1,5 +1,5 @@
 /******************************************************************************
- * @file     startup_ARMCA9.s
+ * @file     startup_ARMCA5.s
  * @brief    CMSIS Device System Source File for ARM Cortex-A5 Device Series
  * @version  V1.00
  * @date     01 Nov 2017

--- a/CMSIS/CoreValidation/Layer/Target/CA5/Target.clayer.yml
+++ b/CMSIS/CoreValidation/Layer/Target/CA5/Target.clayer.yml
@@ -24,12 +24,12 @@ layer:
     - script: RTE/Device/ARMCA5/ARMCA5_gcc.ld
       for-compiler:
         - GCC
-    - script: RTE/Device/ARMCA5/ARMCA5_iar.icf
-      for-compiler:
-        - IAR
     - script: RTE/Device/ARMCA5/ARMCA5_clang.ld
       for-compiler:
         - CLANG
+    - script: RTE/Device/ARMCA5/ARMCA5_iar.icf
+      for-compiler:
+        - IAR
     - regions: RTE/Device/ARMCA5/mem_ARMCA5.h
       for-compiler:
         - AC6

--- a/CMSIS/CoreValidation/Project/build.py
+++ b/CMSIS/CoreValidation/Project/build.py
@@ -249,7 +249,7 @@ def cbuild(config):
 
 
 @matrix_command(test_report=ConsoleReport() |
-                            CropReport('<\?xml version="1.0"\?>', '</report>') |
+                            CropReport('<?xml version="1.0"?>', '</report>') |
                             TransformReport('validation.xsl') |
                             JUnitReport(title=lambda title, result: f"{result.command.config.compiler}."
                                                                     f"{result.command.config.optimize}."


### PR DESCRIPTION
- wrong filename in file header
- Use the same order in the Target clayer file for CA5 as it is used in CA7 and CA9
- Fix invalid escape sequence in XML statement