### PR TITLE
Fix typos in IAR linker scripts for Cortex-M in ROM1 and RAM1

### DIFF
--- a/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM0/RTE/Device/ARMCM0/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM0plus/RTE/Device/ARMCM0P/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM23/RTE/Device/ARMCM23/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM23NS/RTE/Device/ARMCM23/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM23S/RTE/Device/ARMCM23/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM3/RTE/Device/ARMCM3/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM33/RTE/Device/ARMCM33/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM33NS/RTE/Device/ARMCM33/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM33S/RTE/Device/ARMCM33/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM35P/RTE/Device/ARMCM35P/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM35PNS/RTE/Device/ARMCM35P/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM35PS/RTE/Device/ARMCM35P/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM4/RTE/Device/ARMCM4/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM52/RTE/Device/ARMCM52/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM52/RTE/Device/ARMCM52/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM52NS/RTE/Device/ARMCM52/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM52NS/RTE/Device/ARMCM52/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM52S/RTE/Device/ARMCM52/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM52S/RTE/Device/ARMCM52/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM55/RTE/Device/ARMCM55/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM55NS/RTE/Device/ARMCM55/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM55S/RTE/Device/ARMCM55/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM7/RTE/Device/ARMCM7/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM85/RTE/Device/ARMCM85/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM85NS/RTE/Device/ARMCM85/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif

--- a/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/iar_linker_script.icf
+++ b/CMSIS/CoreValidation/Layer/Target/CM85S/RTE/Device/ARMCM85/iar_linker_script.icf
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited. All rights reserved.
+ * Copyright (c) 2023-2024 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,7 +25,7 @@ define memory mem with size = 4G;
 #endif
 
 #if __ROM1_SIZE > 0
-  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM0_BASE+__ROM1_SIZE-1)];
+  define region ROM1_region = mem:[from __ROM1_BASE to (__ROM1_BASE+__ROM1_SIZE-1)];
 #else
   define region ROM1_region = [];
 #endif
@@ -51,7 +51,7 @@ define region ROM_region = ROM0_region |  ROM1_region | ROM2_region | ROM3_regio
 #endif
 
 #if __RAM1_SIZE > 0
-  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM0_BASE+__RAM1_SIZE-1)];
+  define region RAM1_region = mem:[from __RAM1_BASE to (__RAM1_BASE+__RAM1_SIZE-1)];
 #else
   define region RAM1_region = [];
 #endif


### PR DESCRIPTION
Note: This bug was from CMSIS-Toolbox which was fixed (https://github.com/Open-CMSIS-Pack/devtools/pull/1378).