### PR TITLE
Fix __UQADD8 and __UADD8 return value descriptions

### DIFF
--- a/CMSIS/Documentation/Doxygen/Core/src/ref_cm4_simd.txt
+++ b/CMSIS/Documentation/Doxygen/Core/src/ref_cm4_simd.txt
@@ -154,10 +154,10 @@ uint32_t __SHADD8(uint32_t val1, uint32_t val2);
     \param      val2    second four 8-bit summands for each addition.
 
     \returns
-            \li the halved addition of the first bytes from each operand, in the first byte of the return value.
-            \li the halved addition of the second bytes from each operand, in the second byte of the return value.
-            \li the halved addition of the third bytes from each operand, in the third byte of the return value.
-            \li the halved addition of the fourth bytes from each operand, in the fourth byte of the return value.
+            \li the addition of the first bytes from each operand, in the first byte of the return value.
+            \li the addition of the second bytes from each operand, in the second byte of the return value.
+            \li the addition of the third bytes from each operand, in the third byte of the return value.
+            \li the addition of the fourth bytes from each operand, in the fourth byte of the return value.
 
     \par
             Each bit in APSR.GE is set or cleared for each byte in the return value, depending on the results of the operation.
@@ -191,10 +191,10 @@ uint32_t __UADD8(uint32_t val1, uint32_t val2);
     \param      val2    second four 8-bit summands.
 
     \returns
-            \li the halved addition of the first bytes in each operand, in the first byte of the return value.
-            \li the halved addition of the second bytes in each operand, in the second byte of the return value.
-            \li the halved addition of the third bytes in each operand, in the third byte of the return value.
-            \li the halved addition of the fourth bytes in each operand, in the fourth byte of the return value.
+            \li the saturated addition of the first bytes in each operand, in the first byte of the return value.
+            \li the saturated addition of the second bytes in each operand, in the second byte of the return value.
+            \li the saturated addition of the third bytes in each operand, in the third byte of the return value.
+            \li the saturated addition of the fourth bytes in each operand, in the fourth byte of the return value.
 
     \par
             The results are saturated to the 8-bit unsigned integer range 0 \< x \< 2<sup>8</sup> - 1.


### PR DESCRIPTION
`__UQADD8` and `__UADD8` incorrectly claimed their return values contain halved results, but that is not the case.