### PR TITLE
Core: added define guard __ARM_FEATURE_CMSE (#171)

### DIFF
--- a/CMSIS/Core/Include/m-profile/cmsis_armclang_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_armclang_m.h
@@ -56,7 +56,7 @@
 #define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section("RESET")))
 #endif
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 #ifndef __STACK_SEAL
 #define __STACK_SEAL              Image$$STACKSEAL$$ZI$$Base
 #endif
@@ -69,11 +69,12 @@
 #define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
 #endif
 
-
-__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop)
+{
   *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
-  }
+}
 #endif
+
 
 #if (__ARM_ARCH_ISA_THUMB >= 2)
 /**
@@ -119,7 +120,6 @@ __STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
   @{
  */
 
-
 /**
   \brief   Get Control Register
   \details Returns the content of the Control Register.
@@ -134,7 +134,7 @@ __STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Control Register (non-secure)
   \details Returns the content of the non-secure Control Register when in secure mode.
@@ -162,7 +162,7 @@ __STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Control Register (non-secure)
   \details Writes the given value to the non-secure Control Register when in secure state.
@@ -232,7 +232,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Process Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
@@ -259,7 +259,7 @@ __STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Process Stack Pointer (non-secure)
   \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
@@ -286,7 +286,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Main Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
@@ -313,7 +313,7 @@ __STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Main Stack Pointer (non-secure)
   \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
@@ -326,7 +326,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
 #endif
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
@@ -367,7 +367,7 @@ __STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Priority Mask (non-secure)
   \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
@@ -394,7 +394,7 @@ __STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Priority Mask (non-secure)
   \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
@@ -422,7 +422,7 @@ __STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Base Priority (non-secure)
   \details Returns the current value of the non-secure Base Priority register when in secure state.
@@ -449,7 +449,7 @@ __STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Base Priority (non-secure)
   \details Assigns the given value to the non-secure Base Priority register when in secure state.
@@ -488,7 +488,7 @@ __STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Fault Mask (non-secure)
   \details Returns the current value of the non-secure Fault Mask register when in secure state.
@@ -515,7 +515,7 @@ __STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Fault Mask (non-secure)
   \details Assigns the given value to the non-secure Fault Mask register when in secure state.
@@ -542,9 +542,9 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -554,7 +554,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 #endif
 }
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Process Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -565,8 +565,8 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -589,9 +589,9 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
  */
 __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -600,7 +600,7 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Process Stack Pointer (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -611,8 +611,8 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
  */
 __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -632,9 +632,9 @@ __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -645,7 +645,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Main Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -656,8 +656,8 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -679,9 +679,9 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
  */
 __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -690,7 +690,7 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Main Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -701,8 +701,8 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
  */
 __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -710,6 +710,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 #endif
 }
 #endif
+
 #endif /* (__ARM_ARCH >= 8) */
 /** @} end of CMSIS_Core_RegAccFunctions */
 
@@ -812,7 +813,7 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
   return (result);
 }
 #endif /* (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)) */
- /** @} end of group CMSIS_SIMD_intrinsics */
+/** @} end of group CMSIS_SIMD_intrinsics */
 
 
 #endif /* __CMSIS_ARMCLANG_M_H */

--- a/CMSIS/Core/Include/m-profile/cmsis_clang_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_clang_m.h
@@ -62,7 +62,7 @@
 #define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".vectors")))
 #endif
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 #ifndef __STACK_SEAL
 #define __STACK_SEAL              __stack_seal
 #endif
@@ -75,10 +75,10 @@
 #define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
 #endif
 
-
-__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop)
+{
   *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
-  }
+}
 #endif
 
 
@@ -119,12 +119,12 @@ __STATIC_FORCEINLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
 }
 #endif /* (__ARM_ARCH_ISA_THUMB >= 2) */
 
+
 /* ###########################  Core Function Access  ########################### */
 /** \ingroup  CMSIS_Core_FunctionInterface
     \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
   @{
  */
-
 
 /**
   \brief   Get Control Register
@@ -140,7 +140,7 @@ __STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Control Register (non-secure)
   \details Returns the content of the non-secure Control Register when in secure mode.
@@ -168,7 +168,7 @@ __STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Control Register (non-secure)
   \details Writes the given value to the non-secure Control Register when in secure state.
@@ -238,7 +238,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Process Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
@@ -265,7 +265,7 @@ __STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Process Stack Pointer (non-secure)
   \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
@@ -292,7 +292,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Main Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
@@ -319,7 +319,7 @@ __STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Main Stack Pointer (non-secure)
   \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
@@ -332,7 +332,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
 #endif
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
@@ -373,7 +373,7 @@ __STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Priority Mask (non-secure)
   \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
@@ -400,7 +400,7 @@ __STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Priority Mask (non-secure)
   \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
@@ -428,7 +428,7 @@ __STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Base Priority (non-secure)
   \details Returns the current value of the non-secure Base Priority register when in secure state.
@@ -455,7 +455,7 @@ __STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Base Priority (non-secure)
   \details Assigns the given value to the non-secure Base Priority register when in secure state.
@@ -494,7 +494,7 @@ __STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Fault Mask (non-secure)
   \details Returns the current value of the non-secure Fault Mask register when in secure state.
@@ -521,7 +521,7 @@ __STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Fault Mask (non-secure)
   \details Assigns the given value to the non-secure Fault Mask register when in secure state.
@@ -548,9 +548,9 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -560,7 +560,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 #endif
 }
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Process Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -571,8 +571,8 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -595,9 +595,9 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
  */
 __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -606,7 +606,7 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Process Stack Pointer (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -617,8 +617,8 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
  */
 __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -638,9 +638,9 @@ __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -651,7 +651,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Main Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -662,8 +662,8 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -685,9 +685,9 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
  */
 __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -696,7 +696,7 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Main Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -707,8 +707,8 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
  */
 __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -718,12 +718,15 @@ __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 #endif
 
 #endif /* (__ARM_ARCH >= 8) */
+/** @} end of CMSIS_Core_RegAccFunctions */
+
 
 /* ###################  Compiler specific Intrinsics  ########################### */
 /** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
   Access to dedicated SIMD instructions
   @{
 */
+
 #if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
 #define     __SADD8                 __sadd8
 #define     __QADD8                 __qadd8
@@ -815,10 +818,8 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
   __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
   return (result);
 }
-
 #endif /* (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)) */
- /** @} end of group CMSIS_SIMD_intrinsics */
-/** @} end of CMSIS_Core_RegAccFunctions */
+/** @} end of group CMSIS_SIMD_intrinsics */
 
 
 #endif /* __CMSIS_CLANG_M_H */

--- a/CMSIS/Core/Include/m-profile/cmsis_gcc_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_gcc_m.h
@@ -106,8 +106,8 @@ __STATIC_FORCEINLINE __NO_RETURN void __cmsis_start(void)
 #define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
 #endif
 
-
-__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop)
+{
   *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
 }
 #endif
@@ -542,8 +542,8 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
 __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
-       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -565,7 +565,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -589,8 +589,8 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
 __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
-       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -611,7 +611,7 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -632,8 +632,8 @@ __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
 __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
-       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -656,7 +656,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -679,8 +679,8 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
 __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
-       (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -701,7 +701,7 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 {
 #if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
-      !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -711,7 +711,6 @@ __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 #endif
 
 #endif /* (__ARM_ARCH >= 8) */
-
-/*@} end of CMSIS_Core_RegAccFunctions */
+/** @} end of CMSIS_Core_RegAccFunctions */
 
 #endif /* __CMSIS_GCC_M_H */

--- a/CMSIS/Core/Include/m-profile/cmsis_tiarmclang_m.h
+++ b/CMSIS/Core/Include/m-profile/cmsis_tiarmclang_m.h
@@ -106,6 +106,7 @@
   #define __ALIAS(x)                             __attribute__ ((alias(x)))
 #endif
 
+
 /* #########################  Startup and Lowlevel Init  ######################## */
 #ifndef __PROGRAM_START
 #define __PROGRAM_START           _c_int00
@@ -127,7 +128,7 @@
 #define __VECTOR_TABLE_ATTRIBUTE  __attribute__((used, section(".intvecs")))
 #endif
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 #ifndef __STACK_SEAL
 #define __STACK_SEAL              Image$$STACKSEAL$$ZI$$Base
 #endif
@@ -140,8 +141,8 @@
 #define __TZ_STACK_SEAL_VALUE     0xFEF5EDA5FEF5EDA5ULL
 #endif
 
-
-__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop) {
+__STATIC_FORCEINLINE void __TZ_set_STACKSEAL_S (uint32_t* stackTop)
+{
   *((uint64_t *)stackTop) = __TZ_STACK_SEAL_VALUE;
 }
 #endif
@@ -724,7 +725,7 @@ __STATIC_FORCEINLINE uint32_t __get_CONTROL(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Control Register (non-secure)
   \details Returns the content of the non-secure Control Register when in secure mode.
@@ -752,7 +753,7 @@ __STATIC_FORCEINLINE void __set_CONTROL(uint32_t control)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Control Register (non-secure)
   \details Writes the given value to the non-secure Control Register when in secure state.
@@ -822,7 +823,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSP(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Process Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
@@ -849,7 +850,7 @@ __STATIC_FORCEINLINE void __set_PSP(uint32_t topOfProcStack)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Process Stack Pointer (non-secure)
   \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
@@ -876,7 +877,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSP(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Main Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
@@ -903,7 +904,7 @@ __STATIC_FORCEINLINE void __set_MSP(uint32_t topOfMainStack)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Main Stack Pointer (non-secure)
   \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
@@ -916,7 +917,7 @@ __STATIC_FORCEINLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
 #endif
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Stack Pointer (non-secure)
   \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
@@ -957,7 +958,7 @@ __STATIC_FORCEINLINE uint32_t __get_PRIMASK(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Priority Mask (non-secure)
   \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
@@ -984,7 +985,7 @@ __STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Priority Mask (non-secure)
   \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
@@ -1034,7 +1035,7 @@ __STATIC_FORCEINLINE uint32_t __get_BASEPRI(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Base Priority (non-secure)
   \details Returns the current value of the non-secure Base Priority register when in secure state.
@@ -1061,7 +1062,7 @@ __STATIC_FORCEINLINE void __set_BASEPRI(uint32_t basePri)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Base Priority (non-secure)
   \details Assigns the given value to the non-secure Base Priority register when in secure state.
@@ -1100,7 +1101,7 @@ __STATIC_FORCEINLINE uint32_t __get_FAULTMASK(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Fault Mask (non-secure)
   \details Returns the current value of the non-secure Fault Mask register when in secure state.
@@ -1127,7 +1128,7 @@ __STATIC_FORCEINLINE void __set_FAULTMASK(uint32_t faultMask)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Fault Mask (non-secure)
   \details Assigns the given value to the non-secure Fault Mask register when in secure state.
@@ -1154,9 +1155,9 @@ __STATIC_FORCEINLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
  */
 __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -1166,7 +1167,7 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
 #endif
 }
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Process Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -1177,8 +1178,8 @@ __STATIC_FORCEINLINE uint32_t __get_PSPLIM(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -1201,9 +1202,9 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_PSPLIM_NS(void)
  */
 __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -1212,7 +1213,7 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Process Stack Pointer (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -1223,8 +1224,8 @@ __STATIC_FORCEINLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
  */
 __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure PSPLIM is RAZ/WI */
   (void)ProcStackPtrLimit;
 #else
@@ -1244,9 +1245,9 @@ __STATIC_FORCEINLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
  */
 __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -1257,7 +1258,7 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Get Main Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -1268,8 +1269,8 @@ __STATIC_FORCEINLINE uint32_t __get_MSPLIM(void)
  */
 __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   return (0U);
 #else
@@ -1291,9 +1292,9 @@ __STATIC_FORCEINLINE uint32_t __TZ_get_MSPLIM_NS(void)
  */
 __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 {
-#if (((__ARM_ARCH_8M_MAIN__   < 1) && \
-      (__ARM_ARCH_8_1M_MAIN__ < 1)    ) && \
-     (__ARM_FEATURE_CMSE < 3)              )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)) && \
+     (!defined (__ARM_FEATURE_CMSE  ) || (__ARM_FEATURE_CMSE   < 3)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -1302,7 +1303,7 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
 }
 
 
-#if (__ARM_FEATURE_CMSE == 3)
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3)
 /**
   \brief   Set Main Stack Pointer Limit (non-secure)
   Devices without ARMv8-M Main Extensions (i.e. Cortex-M23) lack the non-secure
@@ -1313,8 +1314,8 @@ __STATIC_FORCEINLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
  */
 __STATIC_FORCEINLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
 {
-#if ((__ARM_ARCH_8M_MAIN__   < 1) && \
-     (__ARM_ARCH_8_1M_MAIN__ < 1)    )
+#if (!(defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) && \
+     !(defined (__ARM_ARCH_8_1M_MAIN__ ) && (__ARM_ARCH_8_1M_MAIN__ == 1)))
   /* without main extensions, the non-secure MSPLIM is RAZ/WI */
   (void)MainStackPtrLimit;
 #else
@@ -1365,7 +1366,7 @@ __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
   @{
 */
 
-#if (__ARM_FEATURE_DSP == 1)
+#if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
 #define     __SADD8                 __sadd8
 #define     __QADD8                 __qadd8
 #define     __SHADD8                __shadd8
@@ -1443,8 +1444,7 @@ __STATIC_FORCEINLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
   __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
   return (result);
 }
-
-#endif /* (__ARM_FEATURE_DSP == 1) */
+#endif /* (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1)) */
 /** @} end of group CMSIS_SIMD_intrinsics */
 
 


### PR DESCRIPTION
Check if macro __ARM_FEATURE_CMSE is defined before evaluating it's value