### PR TITLE
CMSIS-Core(M): M55/M85 : add CPPWR SU10/11 defines

### DIFF
--- a/CMSIS/Core/Include/core_cm55.h
+++ b/CMSIS/Core/Include/core_cm55.h
@@ -1023,6 +1023,19 @@ typedef struct
   __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
 } ICB_Type;
 
+/** \brief ICB Coprocessor Power Control Register Definitions */
+#define ICB_CPPWR_SUS11_Pos             23U                                               /*!< CPPWR: SUS11 Position */
+#define ICB_CPPWR_SUS11_Msk             (1UL << ICB_CPPWR_SUS11_Pos)                      /*!< CPPWR: SUS11 Mask */
+
+#define ICB_CPPWR_SU11_Pos              22U                                               /*!< CPPWR: SU11 Position */
+#define ICB_CPPWR_SU11_Msk              (1UL << ICB_CPPWR_SU11_Pos)                       /*!< CPPWR: SU11 Mask */
+
+#define ICB_CPPWR_SUS10_Pos             21U                                               /*!< CPPWR: SUS10 Position */
+#define ICB_CPPWR_SUS10_Msk             (1UL << ICB_CPPWR_SUS10_Pos)                      /*!< CPPWR: SUS10 Mask */
+
+#define ICB_CPPWR_SU10_Pos              20U                                               /*!< CPPWR: SU10 Position */
+#define ICB_CPPWR_SU10_Msk              (1UL << ICB_CPPWR_SU10_Pos)                       /*!< CPPWR: SU10 Mask */
+
 /** \brief ICB Auxiliary Control Register Definitions */
 #define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
 #define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */

--- a/CMSIS/Core/Include/core_cm85.h
+++ b/CMSIS/Core/Include/core_cm85.h
@@ -1044,6 +1044,19 @@ typedef struct
   __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
 } ICB_Type;
 
+/** \brief ICB Coprocessor Power Control Register Definitions */
+#define ICB_CPPWR_SUS11_Pos             23U                                               /*!< CPPWR: SUS11 Position */
+#define ICB_CPPWR_SUS11_Msk             (1UL << ICB_CPPWR_SUS11_Pos)                      /*!< CPPWR: SUS11 Mask */
+
+#define ICB_CPPWR_SU11_Pos              22U                                               /*!< CPPWR: SU11 Position */
+#define ICB_CPPWR_SU11_Msk              (1UL << ICB_CPPWR_SU11_Pos)                       /*!< CPPWR: SU11 Mask */
+
+#define ICB_CPPWR_SUS10_Pos             21U                                               /*!< CPPWR: SUS10 Position */
+#define ICB_CPPWR_SUS10_Msk             (1UL << ICB_CPPWR_SUS10_Pos)                      /*!< CPPWR: SUS10 Mask */
+
+#define ICB_CPPWR_SU10_Pos              20U                                               /*!< CPPWR: SU10 Position */
+#define ICB_CPPWR_SU10_Msk              (1UL << ICB_CPPWR_SU10_Pos)                       /*!< CPPWR: SU10 Mask */
+
 /** \brief ICB Auxiliary Control Register Definitions */
 #define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
 #define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */


### PR DESCRIPTION
FP & MVE requires the SU10 to be modified while transitioning to low power state.

Add support for SU10/S11 register fields.
