### PR TITLE
Include tz_context.h header only if TrustZone is available and used but not switched off.

### DIFF
--- a/ARM.CMSIS.pdsc
+++ b/ARM.CMSIS.pdsc
@@ -617,6 +617,7 @@
     <condition id="TrustZone">
       <description>TrustZone</description>
       <require Dtz="TZ"/>
+      <deny Dsecure="TZ-disabled"/>
     </condition>
     <condition id="TZ Secure">
       <description>TrustZone (Secure)</description>


### PR DESCRIPTION
Fixes ARM-software/CMSIS_6#201