### PR TITLE
Bug fix in GIC_GetConfiguration()

### DIFF
--- a/CMSIS/Core/Include/core_ca.h
+++ b/CMSIS/Core/Include/core_ca.h
@@ -1645,7 +1645,7 @@ __STATIC_INLINE void GIC_SetConfiguration(IRQn_Type IRQn, uint32_t int_config)
 */
 __STATIC_INLINE uint32_t GIC_GetConfiguration(IRQn_Type IRQn)
 {
-  return (GICDistributor->ICFGR[IRQn / 16U] >> ((IRQn % 16U) >> 1U));
+  return (GICDistributor->ICFGR[IRQn / 16U] >> ((IRQn % 16U) << 1U)) & 3UL;
 }
 
 /** \brief Set the priority for the given interrupt in the GIC's IPRIORITYR register.


### PR DESCRIPTION
Bit shift in accordance with IRQn % 16 was incorrect, and masking was needed to extract only the IRQn bits. Both fixed.