### PR TITLE
cmse: enable SAU defines for non-secure state

### DIFF
--- a/CMSIS/Core/Include/core_cm23.h
+++ b/CMSIS/Core/Include/core_cm23.h
@@ -948,7 +948,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -1003,7 +1003,7 @@ typedef struct
 #endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 

--- a/CMSIS/Core/Include/core_cm33.h
+++ b/CMSIS/Core/Include/core_cm33.h
@@ -1551,7 +1551,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -1635,7 +1635,7 @@ typedef struct
 #define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 /**

--- a/CMSIS/Core/Include/core_cm35p.h
+++ b/CMSIS/Core/Include/core_cm35p.h
@@ -1551,7 +1551,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -1635,7 +1635,7 @@ typedef struct
 #define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 /**

--- a/CMSIS/Core/Include/core_cm52.h
+++ b/CMSIS/Core/Include/core_cm52.h
@@ -3053,7 +3053,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -3137,7 +3137,7 @@ typedef struct
 #define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 /**

--- a/CMSIS/Core/Include/core_cm55.h
+++ b/CMSIS/Core/Include/core_cm55.h
@@ -3016,7 +3016,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -3100,7 +3100,7 @@ typedef struct
 #define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 /**

--- a/CMSIS/Core/Include/core_cm85.h
+++ b/CMSIS/Core/Include/core_cm85.h
@@ -3040,7 +3040,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -3124,7 +3124,7 @@ typedef struct
 #define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 /**

--- a/CMSIS/Core/Include/core_starmc1.h
+++ b/CMSIS/Core/Include/core_starmc1.h
@@ -1702,7 +1702,7 @@ typedef struct
 #endif
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#if defined (__ARM_FEATURE_CMSE)
 /**
   \ingroup  CMSIS_core_register
   \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
@@ -1786,7 +1786,7 @@ typedef struct
 #define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) */
 
 
 /**


### PR DESCRIPTION
The SAU register defines and bitfields are still useful for applications that are not running in the secure state.

e.g. An application triggers a SecureFault, during which the secure handler preserved the `SFSR` register value in `.noinit` memory. Once rebooted, the non-secure application queries the `SFSR` register and wishes to inspect the bits to determine more precisely the cause.