### PR TITLE
Fix documentation of the Register HPPIR_INTID

### DIFF
--- a/CMSIS/Documentation/Doxygen/Core_A/src/ref_gic.txt
+++ b/CMSIS/Documentation/Doxygen/Core_A/src/ref_gic.txt
@@ -296,8 +296,9 @@ includes control of the end of interrupt (EOI) behavior.
 
 | Bits    | Name          | Function                                                       |
 | :------ | :------------ | :------------------------------------------------------------- |
-| [31:24] | -             | Reserved.                                                      |
-| [23:0]  | INTID         | The INTID of the signaled interrupt.                           |
+| [31:13] | -             | Reserved.                                                      |
+| [12:10] | CPUID         | On a multiprocessor implementation this identifies the processor that generated the interrupt |
+|  [9:0]  | INTID         | The INTID of the signaled interrupt.                           |
 
 \var  __IM uint32_t GICInterface_Type::IIDR
 \details CPU Interface Identification Register


### PR DESCRIPTION
Fix documentation of the Register HPPIR_INTID according to
"ARM Generic Interrupt Controller Architecture version 2.0 Architecture Specification"
Table 4-41 GICC_HPPIR bit assignments

![409053189-dfa13d3e-1650-489b-a8f2-b061ac9afe17](https://github.com/user-attachments/assets/919edcce-ce77-450b-8839-af6555f2249a)
