### PR TITLE
Add missing CPPWR definitions

### DIFF
--- a/CMSIS/Core/Include/core_cm33.h
+++ b/CMSIS/Core/Include/core_cm33.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2009-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -965,6 +965,19 @@ typedef struct
 /** \brief SCnSCB Interrupt Controller Type Register Definitions */
 #define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
 #define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Coprocessor Power Control Register Definitions */
+#define SCnSCB_CPPWR_SUS11_Pos             23U                                         /*!< CPPWR: SUS11 Position */
+#define SCnSCB_CPPWR_SUS11_Msk             (1UL << SCnSCB_CPPWR_SUS11_Pos)             /*!< CPPWR: SUS11 Mask */
+
+#define SCnSCB_CPPWR_SU11_Pos              22U                                         /*!< CPPWR: SU11 Position */
+#define SCnSCB_CPPWR_SU11_Msk              (1UL << SCnSCB_CPPWR_SU11_Pos)              /*!< CPPWR: SU11 Mask */
+
+#define SCnSCB_CPPWR_SUS10_Pos             21U                                         /*!< CPPWR: SUS10 Position */
+#define SCnSCB_CPPWR_SUS10_Msk             (1UL << SCnSCB_CPPWR_SUS10_Pos)             /*!< CPPWR: SUS10 Mask */
+
+#define SCnSCB_CPPWR_SU10_Pos              20U                                         /*!< CPPWR: SU10 Position */
+#define SCnSCB_CPPWR_SU10_Msk              (1UL << SCnSCB_CPPWR_SU10_Pos)              /*!< CPPWR: SU10 Mask */
 
 /*@} end of group CMSIS_SCnotSCB */
 

--- a/CMSIS/Core/Include/core_cm35p.h
+++ b/CMSIS/Core/Include/core_cm35p.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2025 Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -965,6 +965,19 @@ typedef struct
 /** \brief SCnSCB Interrupt Controller Type Register Definitions */
 #define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
 #define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Coprocessor Power Control Register Definitions */
+#define SCnSCB_CPPWR_SUS11_Pos             23U                                         /*!< CPPWR: SUS11 Position */
+#define SCnSCB_CPPWR_SUS11_Msk             (1UL << SCnSCB_CPPWR_SUS11_Pos)             /*!< CPPWR: SUS11 Mask */
+
+#define SCnSCB_CPPWR_SU11_Pos              22U                                         /*!< CPPWR: SU11 Position */
+#define SCnSCB_CPPWR_SU11_Msk              (1UL << SCnSCB_CPPWR_SU11_Pos)              /*!< CPPWR: SU11 Mask */
+
+#define SCnSCB_CPPWR_SUS10_Pos             21U                                         /*!< CPPWR: SUS10 Position */
+#define SCnSCB_CPPWR_SUS10_Msk             (1UL << SCnSCB_CPPWR_SUS10_Pos)             /*!< CPPWR: SUS10 Mask */
+
+#define SCnSCB_CPPWR_SU10_Pos              20U                                         /*!< CPPWR: SU10 Position */
+#define SCnSCB_CPPWR_SU10_Msk              (1UL << SCnSCB_CPPWR_SU10_Pos)              /*!< CPPWR: SU10 Mask */
 
 /*@} end of group CMSIS_SCnotSCB */
 

--- a/CMSIS/Core/Include/core_cm52.h
+++ b/CMSIS/Core/Include/core_cm52.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 Arm Limited. Copyright (c) 2024 Arm Technology (China) Co., Ltd. All rights reserved.
+ * Copyright (c) 2018-2025 Arm Limited. Copyright (c) 2024 Arm Technology (China) Co., Ltd. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -1075,6 +1075,19 @@ typedef struct
   __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
 } ICB_Type;
 
+/** \brief ICB Coprocessor Power Control Register Definitions */
+#define ICB_CPPWR_SUS11_Pos             23U                                               /*!< CPPWR: SUS11 Position */
+#define ICB_CPPWR_SUS11_Msk             (1UL << ICB_CPPWR_SUS11_Pos)                      /*!< CPPWR: SUS11 Mask */
+
+#define ICB_CPPWR_SU11_Pos              22U                                               /*!< CPPWR: SU11 Position */
+#define ICB_CPPWR_SU11_Msk              (1UL << ICB_CPPWR_SU11_Pos)                       /*!< CPPWR: SU11 Mask */
+
+#define ICB_CPPWR_SUS10_Pos             21U                                               /*!< CPPWR: SUS10 Position */
+#define ICB_CPPWR_SUS10_Msk             (1UL << ICB_CPPWR_SUS10_Pos)                      /*!< CPPWR: SUS10 Mask */
+
+#define ICB_CPPWR_SU10_Pos              20U                                               /*!< CPPWR: SU10 Position */
+#define ICB_CPPWR_SU10_Msk              (1UL << ICB_CPPWR_SU10_Pos)                       /*!< CPPWR: SU10 Mask */
+
 /** \brief ICB Auxiliary Control Register Definitions */
 #define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
 #define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
@@ -1556,7 +1569,7 @@ typedef struct
 {
   __IM  uint32_t DCADCRR;               /*!< Offset: 0x000 (R/W)  Direct Cache Access Data Cache Read Register */
   __IM  uint32_t DCAICRR;               /*!< Offset: 0x004 (R/W)  Direct Cache Access Instruction Cache Read Register */
-        uint32_t RESERVED1[2];          
+        uint32_t RESERVED1[2];
   __IOM uint32_t DCADCLR;               /*!< Offset: 0x010 (R/W)  Direct Cache Access Data Cache Location Registers */
   __IOM uint32_t DCAICLR;               /*!< Offset: 0x014 (R/W)  Direct Cache Access Instruction Cache Location Registers */
 } DCAR_Type;
@@ -1737,7 +1750,7 @@ typedef struct
   __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
         uint32_t RESERVED1[2U];
   __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
-  __IM  uint32_t TEBRDATA0;              /*!< Offset: 0x024 (RO)   Storage for corrected data that is associated with an error.*/        
+  __IM  uint32_t TEBRDATA0;              /*!< Offset: 0x024 (RO)   Storage for corrected data that is associated with an error.*/
   __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
   __IM  uint32_t TEBRDATA1;              /*!< Offset: 0x02c (RO)   Storage for corrected data that is associated with an error.*/
 } ErrBnk_Type;
@@ -1900,7 +1913,7 @@ typedef struct
   __IOM uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
   __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
   __IM  uint32_t STLDMPUOR;              /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register */
- 
+
 } STL_Type;
 
 /** \brief STL NVIC Pending Priority Tree Register Definitions */
@@ -1942,17 +1955,17 @@ typedef struct
 /** \brief STL MPU Region Hit Register Definitions */
 #define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
 #define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
- 
+
 #define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
 #define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
- 
+
 /** \brief STL MPU Memory Attributes Register Definitions */
 #define STL_STLDMPUOR_HITREGION_Pos        9U                                         /*!< STL STLDMPUOR: HITREGION Position */
 #define STL_STLDMPUOR_HITREGION_Msk       (0xFFUL << STL_STLDMPUOR_HITREGION_Pos)     /*!< STL STLDMPUOR: HITREGION Mask */
- 
+
 #define STL_STLDMPUOR_ATTR_Pos             0U                                         /*!< STL STLDMPUOR: ATTR Position */
 #define STL_STLDMPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLDMPUOR_ATTR_Pos*/)     /*!< STL STLDMPUOR: ATTR Mask */
- 
+
 /*@}*/ /* end of group STL_Type */
 
 

--- a/CMSIS/Core/Include/core_starmc1.h
+++ b/CMSIS/Core/Include/core_starmc1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2024 Arm Limited.
+ * Copyright (c) 2009-2025 Arm Limited.
  * Copyright (c) 2018-2022 Arm China.
  * All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -1027,6 +1027,19 @@ typedef struct
 /** \brief SCnSCB Interrupt Controller Type Register Definitions */
 #define SCnSCB_ICTR_INTLINESNUM_Pos         0U                                         /*!< ICTR: INTLINESNUM Position */
 #define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
+
+/** \brief SCnSCB Coprocessor Power Control Register Definitions */
+#define SCnSCB_CPPWR_SUS11_Pos             23U                                         /*!< CPPWR: SUS11 Position */
+#define SCnSCB_CPPWR_SUS11_Msk             (1UL << SCnSCB_CPPWR_SUS11_Pos)             /*!< CPPWR: SUS11 Mask */
+
+#define SCnSCB_CPPWR_SU11_Pos              22U                                         /*!< CPPWR: SU11 Position */
+#define SCnSCB_CPPWR_SU11_Msk              (1UL << SCnSCB_CPPWR_SU11_Pos)              /*!< CPPWR: SU11 Mask */
+
+#define SCnSCB_CPPWR_SUS10_Pos             21U                                         /*!< CPPWR: SUS10 Position */
+#define SCnSCB_CPPWR_SUS10_Msk             (1UL << SCnSCB_CPPWR_SUS10_Pos)             /*!< CPPWR: SUS10 Mask */
+
+#define SCnSCB_CPPWR_SU10_Pos              20U                                         /*!< CPPWR: SU10 Position */
+#define SCnSCB_CPPWR_SU10_Msk              (1UL << SCnSCB_CPPWR_SU10_Pos)              /*!< CPPWR: SU10 Mask */
 
 /*@} end of group CMSIS_SCnotSCB */
 


### PR DESCRIPTION
Added missing Coprocessor Power Control Register Definitions to the v8m-mainline cpus.