### PR TITLE
Fix description of execute-never (XN) bit abstraction

### DIFF
--- a/CMSIS/Core/Include/m-profile/armv8m_mpu.h
+++ b/CMSIS/Core/Include/m-profile/armv8m_mpu.h
@@ -127,7 +127,7 @@
  * Execute-never
  * XN = Execute-never, EX = Executable
  */
-/** \brief Normal memory, Execution only permitted if read permitted */
+/** \brief Normal memory, Execution not permitted */
 #define ARM_MPU_XN (1U)
 
 /** \brief Normal memory, Execution only permitted if read permitted */


### PR DESCRIPTION
---

Copy-Paste error, as both bit values describe the same behavior. This fixes the description to align with the  Arm v8-M architecture reference manual.