### PR TITLE
fix AArch64 GCC FPSCR intrinsics

### DIFF
--- a/CMSIS/Core/Include/cmsis_gcc.h
+++ b/CMSIS/Core/Include/cmsis_gcc.h
@@ -843,7 +843,13 @@ __STATIC_FORCEINLINE void __disable_irq(void)
 __STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
 {
 #if (defined(__ARM_FP) && (__ARM_FP >= 1))
-  return (__builtin_arm_get_fpscr());
+  #if __has_builtin(__builtin_arm_get_fpscr) 
+    return (__builtin_arm_get_fpscr());
+  #else
+    uint32_t result;
+    __ASM volatile ("VMRS %0, fpscr" : "=r" (result) );
+    return(result);
+  #endif
 #else
   return (0U);
 #endif
@@ -858,7 +864,11 @@ __STATIC_FORCEINLINE uint32_t __get_FPSCR(void)
 __STATIC_FORCEINLINE void __set_FPSCR(uint32_t fpscr)
 {
 #if (defined(__ARM_FP) && (__ARM_FP >= 1))
-  __builtin_arm_set_fpscr(fpscr);
+  #if __has_builtin(__builtin_arm_set_fpscr)
+    __builtin_arm_set_fpscr(fpscr);
+  #else
+    __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc", "memory");
+  #endif
 #else
   (void)fpscr;
 #endif


### PR DESCRIPTION
AArch64 GCC does not have the __builtin_arm_set_fpscr() and __builtin_arm_get_fpscr() functions.

https://gcc.gnu.org/onlinedocs/gcc/AArch64-Built-in-Functions.html

Use the same ASM inserts as before commit 30e56dafebc6d5427d68e8fde2307b1114b6a01a.