### PR TITLE
Issue #264: cmsis_iccarm.h prototype fix

### DIFF
--- a/CMSIS/Core/Include/cmsis_iccarm.h
+++ b/CMSIS/Core/Include/cmsis_iccarm.h
@@ -243,7 +243,7 @@ __IAR_FT int16_t __REVSH(int16_t val)
  * Fixed in EWARM 9.50.i2
  */
 
-__IAR_FT void __CLREX() {
+__IAR_FT void __CLREX(void) {
   __ASM volatile("CLREX" ::: "memory"); 
 }
 
@@ -464,12 +464,12 @@ __IAR_FT void __STRT(uint32_t value, volatile uint32_t *addr)
 #if (defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH_ISA_THUMB >= 2)
 // This is not really fault_irq on Cortex-not-M. However 
 // there seems to be code that assumes this.
-  __IAR_FT void __disable_fault_irq()
+  __IAR_FT void __disable_fault_irq(void)
   {
     __ASM volatile ("CPSID F" ::: "memory");
   }
 
-  __IAR_FT void __enable_fault_irq()
+  __IAR_FT void __enable_fault_irq(void)
   {
     __ASM volatile ("CPSIE F" ::: "memory");
   }


### PR DESCRIPTION
The fix for [issue#264](https://github.com/ARM-software/CMSIS_6/issues/264). void keyword is added as a function argument.