### PR TITLE
SCB_DisableDCache: always clean/invalidate stack locals after D-Cache disable

### DIFF
--- a/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
+++ b/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
@@ -195,19 +195,19 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     SCB->CCR &= ~(uint32_t)SCB_CCR_DC_Msk;  /* disable D-Cache */
     __DSB();
 
-    #if !defined(__OPTIMIZE__)
-      /*
-       * For the endless loop issue with no optimization builds.
-       * More details, see https://github.com/ARM-software/CMSIS_5/issues/620
-       *
-       * The issue only happens when local variables are in stack. If
-       * local variables are saved in general purpose register, then the function
-       * is OK.
-       *
-       * When local variables are in stack, after disabling the cache, flush the
-       * local variables cache line for data consistency.
-       */
-      /* Clean and invalidate the local variable cache. */
+    /*
+     * For the endless loop issue with no and debug optimization builds.
+     * More details, see https://github.com/ARM-software/CMSIS_5/issues/620
+     * and https://github.com/ARM-software/CMSIS_6/issues/286
+     *
+     * The issue only happens when local variables are in stack. If
+     * local variables are saved in general purpose register, then the function
+     * is OK.
+     *
+     * When local variables are in stack, after disabling the cache, flush the
+     * local variables cache line for data consistency.
+     */
+    /* Clean and invalidate the local variable cache. */
     #if defined(__ICCARM__)
     /* As we can't align the stack to the cache line size, invalidate each of the variables */
       SCB->DCCIMVAC = (uint32_t)&locals.sets;
@@ -216,9 +216,8 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     #else
       SCB->DCCIMVAC = (uint32_t)&locals;
     #endif
-      __DSB();
-      __ISB();
-    #endif
+    __DSB();
+    __ISB();
 
     locals.ccsidr = SCB->CCSIDR;
                                             /* clean & invalidate D-Cache */

--- a/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
+++ b/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
@@ -196,16 +196,18 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     __DSB();
 
     /*
-     * For the endless loop issue with no and debug optimization builds.
-     * More details, see https://github.com/ARM-software/CMSIS_5/issues/620
-     * and https://github.com/ARM-software/CMSIS_6/issues/286
+     * Work around an endless loop issue that can occur when local variables
+     * are stored on the stack. More details, see
+     * https://github.com/ARM-software/CMSIS_5/issues/620 and
+     * https://github.com/ARM-software/CMSIS_6/issues/286.
      *
-     * The issue only happens when local variables are in stack. If
-     * local variables are saved in general purpose register, then the function
-     * is OK.
+     * The issue only happens when local variables are in stack memory. If
+     * local variables are kept in general purpose registers only, then the
+     * function is OK.
      *
-     * When local variables are in stack, after disabling the cache, flush the
-     * local variables cache line for data consistency.
+     * When local variables are in stack memory, after disabling the cache,
+     * flush the cache line(s) covering the local variables for data
+     * consistency.
      */
     /* Clean and invalidate the local variable cache. */
     #if defined(__ICCARM__)


### PR DESCRIPTION
## Summary

Always perform the cache clean/invalidate sequence for the stack-resident local
variables in `SCB_DisableDCache()`, independent of the optimization level.

## Motivation / Problem

The current implementation only does this when `__OPTIMIZE__` is not defined.
However, even with optimization enabled (e.g. `-Og`), compilers may still spill
locals to the stack depending on register pressure and code generation.

If D-Cache is disabled while relevant locals still reside in cacheable stack
memory, stale values may later be read from RAM. This can lead to data
inconsistency and, in some cases, endless loops.

## Change

Remove the `!defined(__OPTIMIZE__)` guard so the local-variable cache
maintenance is always executed.


Related to #286