### PR TITLE
Short-circuit dcache disable

### DIFF
--- a/CMSIS/Core/Include/core_starmc1.h
+++ b/CMSIS/Core/Include/core_starmc1.h
@@ -3326,6 +3326,11 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     uint32_t sets;
     uint32_t ways;
 
+    /* Return if D-cache is not enabled (prevent flushing junk after POR) */
+    if ((SCB->CCR & SCB_CCR_DC_Msk) == 0U) {
+      return;
+    }
+
     SCB->CSSELR = 0U;                       /* select Level 1 data cache */
     __DSB();
 

--- a/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
+++ b/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
@@ -189,6 +189,11 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
     #endif
     ;
 
+    /* Return if D-cache is not enabled (prevent flushing junk after POR) */
+    if ((SCB->CCR & SCB_CCR_DC_Msk) == 0U) {
+      return;
+    }
+
     SCB->CSSELR = 0U;                       /* select Level 1 data cache */
     __DSB();
 


### PR DESCRIPTION
Do not attempt to clean and invalidate the DCache if SCB_DisableDCache is invoked when it was not enabled in the first place. This prevents landing junk into RAM after a POR.