### PR TITLE
Add Zephyr module metadata

### DIFF
--- a/zephyr/README.md
+++ b/zephyr/README.md
@@ -1,0 +1,30 @@
+# Zephyr RTOS Integration
+
+This directory contains metadata to allow CMSIS_6 to be consumed as a
+module by the Zephyr RTOS.
+
+## Purpose
+
+The files in this directory exist solely to support integration with
+Zephyr's build system. They enable Zephyr to include CMSIS_6 as an
+external module without requiring any modifications to the CMSIS_6
+source tree.
+
+## Scope
+
+- This directory is **only used by Zephyr**.
+- It does **not** affect CMSIS_6 functionality or usage outside of Zephyr.
+- It is intentionally minimal to avoid introducing any dependencies on
+  Zephyr within the rest of the CMSIS_6 repository.
+
+## CMake and Kconfig
+
+Any references to CMake or Kconfig in this directory are specific to Zephyr's
+module integration mechanism. Zephyr-specific build logic is kept outside of
+the CMSIS_6.
+
+## More Information
+
+For details on Zephyr and its modules, see:
+- https://docs.zephyrproject.org/latest/
+- https://docs.zephyrproject.org/latest/develop/modules.html

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: cmsis_6
+build:
+  cmake-ext: true
+  kconfig-ext: true


### PR DESCRIPTION
Add zephyr/module.yml to allow CMSIS_6 to be consumed as a Zephyr module.

This enables Zephyr to use CMSIS_6 directly from upstream without requiring downstream changes in this repository, allowing straightforward synchronization with future updates (e.g. via standard GitHub fork sync workflows).

Use external CMake and Kconfig integration so that all Zephyr-specific build logic remains in the Zephyr repository. This keeps CMSIS_6 independent of any particular build system and preserves portability for non-Zephyr users.

The change is minimal and does not affect existing CMSIS_6 users or workflows.

For more details on Zephyr modules, see:
https://docs.zephyrproject.org/latest/develop/modules.html