### PR TITLE
fix(MPU): promote attr to uint32_t before shifting in ARM_MPU_SetMemAttrEx

### DIFF
--- a/CMSIS/Core/Include/m-profile/armv8m_mpu.h
+++ b/CMSIS/Core/Include/m-profile/armv8m_mpu.h
@@ -259,12 +259,17 @@ __STATIC_INLINE void ARM_MPU_SetMemAttrEx(MPU_Type* mpu, uint8_t idx, uint8_t at
   const uint8_t reg = idx / 4U;
   const uint32_t pos = ((idx % 4U) * 8U);
   const uint32_t mask = 0xFFU << pos;
+  /* attr is uint8_t; integer promotion makes "attr << pos" a signed int
+   * shift, which overflows int's representable range (and is undefined
+   * behavior) once attr >= 0x80 and pos == 24. Promote to uint32_t first
+   * so the shift is unsigned and cannot overflow. */
+  const uint32_t val = (uint32_t)attr << pos;
 
   if (reg >= (sizeof(mpu->MAIR) / sizeof(mpu->MAIR[0]))) {
     return; // invalid index
   }
 
-  mpu->MAIR[reg] = ((mpu->MAIR[reg] & ~mask) | ((attr << pos) & mask));
+  mpu->MAIR[reg] = ((mpu->MAIR[reg] & ~mask) | (val & mask));
 }
 
 /** Set the memory attribute encoding.

--- a/CMSIS/Core/Include/m-profile/armv8m_mpu.h
+++ b/CMSIS/Core/Include/m-profile/armv8m_mpu.h
@@ -261,7 +261,7 @@ __STATIC_INLINE void ARM_MPU_SetMemAttrEx(MPU_Type* mpu, uint8_t idx, uint8_t at
   const uint32_t mask = 0xFFU << pos;
   /* attr is uint8_t; integer promotion makes "attr << pos" a signed int
    * shift, which overflows int's representable range (and is undefined
-   * behavior) once attr >= 0x80 and pos == 24. Promote to uint32_t first
+   * behaviour) once attr >= 0x80 and pos == 24. Promote to uint32_t first
    * so the shift is unsigned and cannot overflow. */
   const uint32_t val = (uint32_t)attr << pos;
 


### PR DESCRIPTION
Fixes #169

## Problem

`ARM_MPU_SetMemAttrEx` computes `attr << pos` where `attr` is `uint8_t`. Integer promotion converts `attr` to a signed `int` before the shift is evaluated. For `attr >= 0x80` and `pos == 24`, the mathematical result (up to `0xFF000000`) exceeds `INT_MAX`, which is undefined behavior for a signed left shift -- not merely implementation-defined truncation.

## Fix

Promote `attr` to `uint32_t` explicitly before shifting, so the shift is performed in unsigned arithmetic and cannot overflow, matching the fix suggested in the issue.

## Verification

Verified by hand against the issue's analysis (integer-promotion rules for `E1 << E2`, and the resulting range for `attr << pos` at `pos == 24`). No C compiler was available in the environment this patch was authored in, so I was not able to build/run against the test suite directly -- please double-check against CI/local build before merging.