### PR TITLE
SCB_DisableDCache: Always use __ALIGNED attribute for struct locals when using gcc/clang

### DIFF
--- a/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
+++ b/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
@@ -184,7 +184,7 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
       uint32_t sets;
       uint32_t ways;
     } locals
-    #if ((defined(__GNUC__) || defined(__clang__)) && !defined(__OPTIMIZE__))
+    #if ((defined(__GNUC__) || defined(__clang__))
        __ALIGNED(__SCB_DCACHE_LINE_SIZE)
     #endif
     ;

--- a/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
+++ b/CMSIS/Core/Include/m-profile/armv7m_cachel1.h
@@ -184,7 +184,7 @@ __STATIC_FORCEINLINE void SCB_DisableDCache (void)
       uint32_t sets;
       uint32_t ways;
     } locals
-    #if ((defined(__GNUC__) || defined(__clang__))
+    #if defined(__GNUC__) || defined(__clang__)
        __ALIGNED(__SCB_DCACHE_LINE_SIZE)
     #endif
     ;


### PR DESCRIPTION
Struct `locals` was only aligned to the D-cache line size when `__OPTIMIZE__` was not defined. This led to intermittent failures (endless loop) of MIMXRT1166.
This removes the `!defined(__OPTIMIZE__)` condition so the struct is always aligned when building with gcc or clang, for every optimization level.

Related to [#286 ](https://github.com/ARM-software/CMSIS_6/issues/286#issuecomment-5354868237)